### PR TITLE
[ new ] PHOAS for the internal language

### DIFF
--- a/PHOAS.hs
+++ b/PHOAS.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE RankNTypes, DataKinds, KindSignatures, GADTs,
+             MultiParamTypeClasses, FunctionalDependencies,
+             TypeFamilies, PolyKinds, UndecidableInstances,
+             FlexibleInstances, FlexibleContexts, ScopedTypeVariables, StandaloneDeriving,
+             PatternSynonyms, TypeOperators, ConstraintKinds, TupleSections #-}
+module PHOAS(
+  var,
+  var',
+  lam,
+  pi,
+  sg,
+  letin
+  ) where
+
+import Prelude hiding (pi)
+import Data.Proxy
+import Utils
+import Syntax
+
+newtype Included (m :: Nat) (n :: Nat) = Included { rename :: Fin m -> Fin n }
+
+class CIncluded (m :: Nat) (n :: Nat) (b :: Bool) where
+  included :: Proxy b -> Included m n
+
+instance CIncluded m m b where
+  included _ = Included id
+
+instance CIncluded m n (NatLT m n) => CIncluded m (Suc n) True where
+  included _ = Included $ FSuc . rename (included (Proxy :: Proxy (NatLT m n)))
+
+newtype FreshVar m w = FreshVar { var :: forall n. CIncluded (Suc m) n (NatLT (Suc m) n) => En (Syn n) w }
+
+var' :: forall m n w. CIncluded (Suc m) n (NatLT (Suc m) n) => FreshVar m w -> Tm (Syn n) w
+var' = En . var
+
+lam :: forall m w. (FreshVar m w -> Tm (Syn (Suc m)) w) -> Tm (Syn m) w
+lam f = Lam (f $ FreshVar freshVar) where
+
+  freshVar :: forall n. CIncluded (Suc m) n (NatLT (Suc m) n) => En (Syn n) w
+  freshVar = V $ rename (included (Proxy :: Proxy (NatLT (Suc m) n))) (FZero :: Fin (Suc m))
+
+
+pi :: forall m w. Tm (Syn m) w -> (FreshVar m w -> Tm (Syn (Suc m)) w) -> Tm (Syn m) w
+pi s t = RawPi s $ lam t
+
+sg :: forall m w. Tm (Syn m) w -> (FreshVar m w -> Tm (Syn (Suc m)) w) -> Tm (Syn m) w
+sg s t = RawSg s $ lam t
+
+letin :: forall m w. En (Syn m) w -> (FreshVar m w -> Tm (Syn (Suc m)) w) -> Tm (Syn m) w
+letin e t = Let e (t $ FreshVar freshVar) where
+
+  freshVar :: forall n. CIncluded (Suc m) n (NatLT (Suc m) n) => En (Syn n) w
+  freshVar = V $ rename (included (Proxy :: Proxy (NatLT (Suc m) n))) (FZero :: Fin (Suc m))

--- a/Syntax.hs
+++ b/Syntax.hs
@@ -38,6 +38,8 @@ module Syntax(
   pattern Level,
   pattern Ze,
   pattern Su,
+  pattern RawPi,
+  pattern RawSg,
   pattern Pi,
   pattern Sg,
   pattern Fst,
@@ -181,6 +183,9 @@ envHetEq _        _          = False
 pattern Nil = Atom ""
 
 -- Pi, Sg :: Tm p w -> Body p w -> Tm p w
+pattern RawPi s t = Atom "Pi" :& s :& t :& Nil
+pattern RawSg s t = Atom "Sg" :& s :& t :& Nil
+
 pattern Pi s t = Atom "Pi" :& s :& Lam t :& Nil
 pattern Sg s t = Atom "Sg" :& s :& Lam t :& Nil
 
@@ -311,15 +316,6 @@ instance Dischargeable (Tm (Syn Zero)) (Tm (Syn One)) where
 instance Dischargeable Happy Happy where
   discharge _ Happy = Happy -- :)
 
-type family EQ x y where
-  EQ x x = True
-  EQ x y = False
-
-type family OR x y where
-  OR True  y =    True
-  OR x     True  = True
-  OR False y     = y
-  OR x     False = x
 
 type family WorldLT (w :: World)(w' :: World) :: Bool where
   WorldLT w (Bind w') = WorldLE w w'

--- a/Test.hs
+++ b/Test.hs
@@ -6,12 +6,14 @@
              TypeFamilies, StandaloneDeriving #-}
 module Test where
 
+import Prelude hiding (pi)
 import Utils
 import Syntax
+import PHOAS
 import TypeCheck
 
 import Layout
-import Raw
+import Raw hiding (var)
 import ProofState
 
 
@@ -45,20 +47,20 @@ testReport (name,test) = case runTest test of
 
 passtests = 
  [("test-1",ISKIND (El (Pi (Set Ze) (Set Ze))))
- ,("test0",CHECK (El (Pi (Set Ze) (Set Ze))) (Lam (En (V FZero))))
- ,("test1",INFER ((Lam (En (V FZero)) ::: El (Pi (Set (Su Ze)) (Set (Su Ze)))) :/ (Set Ze)) (El (Set (Su Ze))))
- ,("test1.5",ISKIND (El (Pi (Set Ze) (Pi (En (V FZero)) (En (V (FSuc (FZero))))))))
- ,("test2",CHECK (El (Pi (Set Ze) (Pi (En (V FZero)) (En (V (FSuc (FZero))))))) (Lam (Lam (En (V FZero)))))
+ ,("test0",CHECK (El (Pi (Set Ze) (Set Ze))) (lam var'))
+ ,("test1",INFER ((lam var' ::: El (Pi (Set (Su Ze)) (Set (Su Ze)))) :/ (Set Ze)) (El (Set (Su Ze))))
+ ,("test1.5",ISKIND (El (pi (Set Ze) $ \ a -> Pi (var' a) (var' a))))
+ ,("test2",CHECK (El (pi (Set Ze) $ \ a -> Pi (var' a) (var' a))) (Lam $ lam $ \ x -> var' x))
  ,("test3",INFER (Lam (Lam (En (V FZero))) ::: El (Pi (Set (Su Ze)) (Pi (En (V FZero)) (En (V (FSuc (FZero)))))) :/ (Set Ze)) (El (Pi (Set Ze) (Set Ze))))
- ,("test4",INFER (Lam (Lam (En (V FZero))) ::: El (Pi (Set (Su (Su Ze))) (Pi (En (V FZero)) (En (V (FSuc (FZero)))))) :/ (Set (Su Ze)) :/ (Set Ze)) (El (Set (Su Ze))))
+ ,("test4",INFER ((Lam $ lam var') ::: El (pi (Set (Su (Su Ze))) $ \ a -> Pi (var' a) (var' a)) :/ (Set (Su Ze)) :/ (Set Ze)) (El (Set (Su Ze))))
  ,("test5",CHECK (El (Sg (Set (Su Ze)) (Set (Su Ze)))) ((Set Ze) :& (Set Ze)))
  ,("test6",INFER ((((Set Ze) :& (Set Ze)) ::: El (Sg (Set (Su Ze)) (Set (Su Ze)))) :/ Fst) (El (Set (Su Ze))))
  ,("test7",INFER ((((Set Ze) :& (Set Ze)) ::: El (Sg (Set (Su Ze)) (Set (Su Ze)))) :/ Snd) (El (Set (Su Ze))))
  ,("test8",CHECK (El (Sg (Set (Su (Su Ze))) (En (V FZero)))) ((Set (Su Ze)) :& (Set Ze)))
  ,("test9",CHECK (El (Pi (Sg (Set Ze) (Set Ze)) (Set Ze))) (Lam (En ((V FZero) :/ Fst))))
- ,("test0",NORM (Lam (En (V FZero)) ::: El (Pi (Sg (Set Ze) (Set Ze)) (Sg (Set Ze) (Set Ze))))
-                   (Lam (En ((:/) (V FZero) (Atom "Fst")) :& En ((:/) (V FZero) (Atom "Snd")))))
- ,("testLet",CHECK (El (Set (Su Ze))) (Let ((Set (Su Ze)) ::: El (Set (Su (Su Ze)))) (En ((Set Ze) ::: El (En (V FZero))))))
+ ,("test0",NORM ((lam var') ::: El (Pi (Sg (Set Ze) (Set Ze)) (Sg (Set Ze) (Set Ze))))
+                 (lam $ \ p -> (En ((:/) (var p) (Atom "Fst")) :& En ((:/) (var p) (Atom "Snd")))))
+ ,("testLet",CHECK (El (Set (Su Ze))) (letin ((Set (Su Ze)) ::: El (Set (Su (Su Ze)))) $ \ x -> (En ((Set Ze) ::: El (var' x)))))
  ]
 
 failtests = map (fmap FAILS)

--- a/Utils.hs
+++ b/Utils.hs
@@ -1,11 +1,29 @@
 {-# LANGUAGE KindSignatures, DataKinds, EmptyCase, GADTs,
              DeriveFunctor, StandaloneDeriving, PolyKinds,
-             TypeOperators, ScopedTypeVariables, RankNTypes #-}
+             TypeOperators, ScopedTypeVariables, RankNTypes,
+             TypeFamilies, UndecidableInstances #-}
 module Utils where
+
+type family EQ x y where
+  EQ x x = True
+  EQ x y = False
+
+type family OR x y where
+  OR True  y =    True
+  OR x     True  = True
+  OR False y     = y
+  OR x     False = x
 
 data Nat = Zero | Suc Nat deriving Show
 
 type One = Suc Zero
+
+type family NatLT (m :: Nat) (n :: Nat) where
+  NatLT m (Suc n) = NatLE m n
+  NatLT _  _      = False
+
+type family NatLE (m :: Nat) (n :: Nat) where
+  NatLE m n = OR (EQ m n) (NatLT m n)
 
 data Fin (n :: Nat) where
   FZero :: Fin (Suc n)


### PR DESCRIPTION
This commit introduces a PHOAS for terms of the internal syntax. This
way we do not have to explicitly write down the `Fin` corresponding
to a given bound variable if we do not want to.

I have added a couple of examples in Test.hs but the gist of it is
that we can use Haskell binders to represent binders in our object
language. E.g. the S, K, I combinators become:

S = lam $ \ f -> lam $ \ g -> lam $ \ x ->
    En (App (App (var f) (var' x)) (En (App (var g) (var' x))))

K = lam $ \ x -> Lam $ var' x

I = lam var'
